### PR TITLE
fix: add missing 'tailwindcss' dependency

### DIFF
--- a/quick-start/mobile-pages/package.json
+++ b/quick-start/mobile-pages/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^14",
     "@types/react": "^17",
     "@types/react-dom": "^17",
+    "tailwindcss": "latest",
     "typescript": "^4"
   },
   "modernConfig": {

--- a/quick-start/website/package.json
+++ b/quick-start/website/package.json
@@ -53,12 +53,13 @@
     "@modern-js/app-tools": "latest",
     "@modern-js/plugin-testing": "latest",
     "@modern-js/plugin-jarvis": "latest",
+    "@modern-js/plugin-tailwindcss": "latest",
     "@types/jest": "^26.0.9",
     "@types/node": "^14",
     "@types/react": "^17",
     "@types/react-dom": "^17",
     "typescript": "^4",
-    "@modern-js/plugin-tailwindcss": "latest"
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c06/hello-modern-2/package.json
+++ b/tutorials/c06/hello-modern-2/package.json
@@ -49,12 +49,13 @@
   "devDependencies": {
     "@modern-js/app-tools": "latest",
     "@modern-js/plugin-jarvis": "latest",
+    "@modern-js/plugin-tailwindcss": "latest",
     "@modern-js/plugin-unbundle": "latest",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "typescript": "^4.4.4",
-    "@modern-js/plugin-tailwindcss": "latest"
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c06/hello-modern-3/package.json
+++ b/tutorials/c06/hello-modern-3/package.json
@@ -50,11 +50,12 @@
     "@modern-js/app-tools": "latest",
     "@modern-js/plugin-jarvis": "latest",
     "@modern-js/plugin-unbundle": "latest",
+    "@modern-js/plugin-tailwindcss": "latest",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "typescript": "^4.4.4",
-    "@modern-js/plugin-tailwindcss": "latest"
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c06/hello-modern-4/package.json
+++ b/tutorials/c06/hello-modern-4/package.json
@@ -50,11 +50,12 @@
     "@modern-js/app-tools": "latest",
     "@modern-js/plugin-jarvis": "latest",
     "@modern-js/plugin-unbundle": "latest",
+    "@modern-js/plugin-tailwindcss": "latest",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "typescript": "^4.4.4",
-    "@modern-js/plugin-tailwindcss": "latest"
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c06/hello-modern-5/package.json
+++ b/tutorials/c06/hello-modern-5/package.json
@@ -49,13 +49,14 @@
   "devDependencies": {
     "@modern-js/app-tools": "latest",
     "@modern-js/plugin-jarvis": "latest",
+    "@modern-js/plugin-storybook": "latest",
+    "@modern-js/plugin-tailwindcss": "latest",
     "@modern-js/plugin-unbundle": "latest",
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
     "typescript": "^4.4.4",
-    "@modern-js/plugin-tailwindcss": "latest",
-    "@modern-js/plugin-storybook": "latest"
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c06/hello-modern-6/package.json
+++ b/tutorials/c06/hello-modern-6/package.json
@@ -57,7 +57,8 @@
     "typescript": "^4.4.4",
     "@modern-js/plugin-tailwindcss": "latest",
     "@modern-js/plugin-storybook": "latest",
-    "@modern-js/plugin-testing": "latest"
+    "@modern-js/plugin-testing": "latest",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c07/hello-modern-2/package.json
+++ b/tutorials/c07/hello-modern-2/package.json
@@ -57,7 +57,8 @@
     "typescript": "^4.4.4",
     "@modern-js/plugin-tailwindcss": "latest",
     "@modern-js/plugin-storybook": "latest",
-    "@modern-js/plugin-testing": "latest"
+    "@modern-js/plugin-testing": "latest",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c08/hello-modern/package.json
+++ b/tutorials/c08/hello-modern/package.json
@@ -57,7 +57,8 @@
     "typescript": "^4.4.4",
     "@modern-js/plugin-tailwindcss": "latest",
     "@modern-js/plugin-storybook": "latest",
-    "@modern-js/plugin-testing": "latest"
+    "@modern-js/plugin-testing": "latest",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c09/hello-modern-2/package.json
+++ b/tutorials/c09/hello-modern-2/package.json
@@ -62,7 +62,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c09/hello-modern-3/package.json
+++ b/tutorials/c09/hello-modern-3/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c10/hello-modern-3/package.json
+++ b/tutorials/c10/hello-modern-3/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c10/hello-modern-4/package.json
+++ b/tutorials/c10/hello-modern-4/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c11/hello-modern-2/package.json
+++ b/tutorials/c11/hello-modern-2/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c11/hello-modern-3/package.json
+++ b/tutorials/c11/hello-modern-3/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c11/hello-modern-4/package.json
+++ b/tutorials/c11/hello-modern-4/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {

--- a/tutorials/c11/hello-modern/package.json
+++ b/tutorials/c11/hello-modern/package.json
@@ -65,7 +65,8 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "tailwindcss": "latest"
   },
   "modernConfig": {
     "runtime": {


### PR DESCRIPTION
When using '@modern-js/plugin-tailwindcss' in modern.js projects, 'tailwindcss' is needed as well. 
This PR will fix the lacking dependency problem.