### PR TITLE
fix: update template css

### DIFF
--- a/quick-start/api-service/src/App.css
+++ b/quick-start/api-service/src/App.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {

--- a/quick-start/micro-frontend/main/src/App.css
+++ b/quick-start/micro-frontend/main/src/App.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {

--- a/quick-start/middle-platform/src/middle-platform/App.css
+++ b/quick-start/middle-platform/src/middle-platform/App.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {

--- a/quick-start/monorepo-component/apps/app/src/App.css
+++ b/quick-start/monorepo-component/apps/app/src/App.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {

--- a/quick-start/monorepo-library/apps/app/src/App.css
+++ b/quick-start/monorepo-library/apps/app/src/App.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {

--- a/quick-start/website/src/pages/index.css
+++ b/quick-start/website/src/pages/index.css
@@ -3,7 +3,7 @@ body {
   padding: 0;
   margin: 0;
   font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
-    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+    Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
 }
 
 * {


### PR DESCRIPTION
Microsoft YaHei就等于微软雅黑。
其中Microsoft YaHei兼容性更好，中文”微软雅黑“在某些版本的浏览器会失效。
当用户将模板css文件内容直接复制到.less中。在dev时，中文”微软雅黑“会导致less发生编译错误。